### PR TITLE
pt-br.yaml

### DIFF
--- a/translations/pt-br.yaml
+++ b/translations/pt-br.yaml
@@ -12,6 +12,40 @@ Replay: Repetir
 Resume: Retomar
 Submit: Enviar
 'Yes': Sim
+please wait: por favor, aguarde
+please wait, setting up: por favor espere, configurando
+return to fullscreen: voltar para tela inteira
+this-field-is-required: Este campo é obrigatório.
+uploading video: enviando vídeo
+
+consent-template-2:
+header: Consentimento para participar da pesquisa
+intro-sentence: Pesquisadores liderados por {name} em {institution} estão conduzindo este estudo, "{experiment}", no Lookit.
+purpose-header: Objetivo
+procedures-header: Procedimentos
+duration-statement: Este estudo leva cerca de {duration} para ser concluído.
+participation-header: Participação
+participation-content:  Você e sua criança são livres para escolher se querem participar deste estudo. Se você e sua criança decidirem participar, não há problema em parar a qualquer momento durante a sessão. Por favor, pause ou interrompa a sessão se sua criança ficar muito agitada ou não quiser participar! Se este for um estudo com múltiplas sessões, não há problema em não concluir todas as sessões.
+payment-header: Remuneração
+data-collection-header: Coleta de dados e gravação de webcam
+data-collection-1:  Durante a sessão, você e sua criança serão gravados pela webcam e pelo microfone do seu computador. As gravações de vídeo e outros dados inseridos são enviados com segurança para a plataforma Lookit e armazenados indefinidamente. No final da sessão, você deverá escolher um nível de privacidade para as gravações da sua webcam. Nesse momento, você terá a opção de retirar seus dados de vídeo. Você pode ver suas gravações anteriores no Lookit a qualquer momento.
+data-collection-2: Os dados são armazenados de forma segura nos servidores do Lookit e por pesquisadores. No entanto, existe sempre um pequeno risco de que dados transmitidos pela Internet possam ser interceptados ou de que a segurança de dados armazenados possa ser comprometida.
+data-collection-3: Nenhum videoclipe será publicado ou compartilhado, a menos que você permita isso ao selecionar um nível de privacidade. Se não recebermos uma gravação de consentimento para esta sessão (o vídeo que você fará à direita) e não pudermos verificar se você concordou em participar, nenhum outro vídeo da sua sessão será visualizado.
+data-use-researchers-header: Uso de dados pelos pesquisadores do estudo
+data-use-researchers-content: O grupo de pesquisa liderado por {name} em {institution} terá acesso a vídeos e outros dados coletados durante esta sessão. Também teremos acesso ao perfil da sua conta, ao questionário demográfico e ao perfil da criança que está participando, incluindo alterações que você fizer no futuro em qualquer uma dessas informações. Poderemos comparar as respostas da sua criança em relação às respostas anteriores a este ou a outros estudos realizados pelo nosso grupo, às respostas dos irmãos a este ou a outros estudos realizados pelo nosso grupo, ou às respostas de questionários demográficos.
+data-use-Lookit-header: Uso de dados pelo Lookit
+data-use-Lookit-content: Como este estudo está sendo realizado na plataforma Lookit, os pesquisadores que trabalham no projeto Lookit no MIT também terão acesso aos dados coletados durante esta sessão, além dos dados da sua conta, perfis de crianças e respostas de questionários demográficos. Esses dados podem ser usados pelo Lookit para detectar e corrigir problemas técnicos ou identificar novos recursos que possam ser úteis. Os dados podem ser usados, também, para fornecer suporte aos pesquisadores do estudo, avaliar a qualidade dos dados (por exemplo, até que ponto um observador consegue dizer para qual direção as crianças estão olhando), avaliar o sucesso do site em alcançar uma população diversificada, e caracterizar o envolvimento familiar (como, por exemplo, observar quais aspectos de um estudo tornam os pais mais interessados em voltar mais tarde).
+publication-header: Publicação de resultados
+publication-contents: Os resultados da pesquisa poderão ser apresentados em eventos científicos ou publicados em revistas científicas. Os dados brutos (como, por exemplo, o tempo do olhar para a esquerda e para a direita da tela) podem ser publicados quando não permitem a identificação das crianças. Nunca publicamos as datas de nascimento ou os nomes das crianças, assim como não publicamos os dados demográficos juntamente com o vídeo da sua criança.
+research-subject-rights-header: Direitos dos participantes da pesquisa
+gdpr-header: Informações sobre o Regulamento Geral de Proteção de Dados (General Data Protection Regulation - GDPR)
+gdpr-personal: Como parte da sua participação, coletaremos certas informações pessoais sobre você, incluindo
+gdpr-sensitive: Além disso, coletaremos dados de categorias especiais, ou seja, suas informações pessoais que são especialmente sensíveis
+gdpr-2: Suas informações pessoais serão transferidas para os Estados Unidos. Você entende que as leis de proteção de dados e privacidade dos Estados Unidos podem não oferecer o mesmo nível de proteção que as do seu país de origem.
+    contact-header: Informação de contato do pesquisador
+contact-statement-1: Este estudo é conduzido por {name} em {institution}. Se você ou sua criança tiverem alguma dúvida ou preocupação sobre este estudo, ou no caso muito improvável de uma lesão relacionada ao estudo, entre em contato com {contact}.
+contact-statement-2: Se você ou sua criança tiverem alguma dúvida ou preocupação sobre a plataforma Lookit, entre em contato com a equipe do Lookit em lookit@mit.edu ou 617 324 4859.
+
 consent-template-5:
   benefits-header: Quais são os benefícios?
   contact-header: Como chegar até nós
@@ -122,6 +156,52 @@ consent-template-5:
     suas gravações. Se você fizer isso, apenas sua gravação de consentimento será
     mantida e todas as outras gravações serão excluídas.
 establishing video connection: estabelecendo conexão de vídeo
+
+consent-garden:
+header: "Consentimento para participação em pesquisa: {experiment} para o Projeto GARDEN"
+intro-sentence: Pesquisadores liderados por {name} em {institution} estão conduzindo este estudo, {experiment}, no Lookit.
+overview-header: Gostaríamos de convidá-lo para participar do nosso estudo!
+overview-content: Como um dos principais cuidadores da sua criança (tutor legal, como um dos pais), você está convidado a participar do {experiment}, que faz parte do Projeto GARDEN da Children Helping Science (Growing and Advancing Research in Development and EducatioN; veja <a href= "https://childrenhelpingscience.com/garden/about" target="_blank" rel="noopener noreferrer">O que é o Projeto GARDEN?</a> para mais detalhes). Este projeto visa compreender melhor como as crianças crescem e se desenvolvem, especialmente, na forma como elas pensam, aprendem e entendem o mundo ao seu redor!<br><br>Neste momento, você está lendo o formulário de consentimento, que lhe dará algumas informações sobre este estudo e o ajudará a escolher se deseja participar. Depois de ler essas informações, você poderá decidir preencher o formulário seguindo as instruções da página. Além disso, você poderá ser convidado para participar de outros estudos do Projeto GARDEN posteriormente, mas este formulário de consentimento é apenas para {experiment}.<br><br>Incentivamos as pessoas a fazerem perguntas, portanto, se você não tiver certeza sobre qualquer parte deste formulário de consentimento ou do estudo, sinta-se à vontade para entrar em contato conosco enviando um e-mail para {contact} antes de decidir se gostaria de participar de {experiment}.
+study-info-header: O que é este estudo e quem o está conduzindo?
+study-info-content: Este é o estudo {experiment} conduzido por {lab} em {institution} como parte do Projeto GARDEN (ver <a href="https://childrenhelpingscience.com/garden/about" target="_blank" rel="noopener noreferrer " >O que é o Projeto GARDEN?</a> para mais detalhes). Neste estudo, {description}.
+purpose-header: Por que você está fazendo este estudo?
+eligibility-header: Quem pode participar?
+procedures-header: O que acontece durante este estudo e quanto tempo levará?
+duration-statement: Este estudo leva cerca de {duration} para ser concluído.
+payment-header: O que recebo por participar deste estudo?
+payment-content: Você receberá um vale-presente de $5 da Amazon.com (<u>utilizável apenas no site dos EUA</u>) o mais rápido possível após participar do estudo (dentro de 7 dias úteis).
+benefits-header: Quais são alguns motivos pelos quais eu poderia querer participar?
+risk-header: Quais são alguns dos motivos pelos quais talvez eu não queira participar?
+risk-content-1: '{experiment} leva cerca de {duration} apenas, mas sua criança pode achar algumas perguntas desinteressantes ou chatas. '
+risk-content-2: 'Sua criança pode {risk_content_discontinue_options}optar por parar de participar a qualquer momento. '
+risk-content-3: Nós te informaremos se tivermos conhecimento de quaisquer outros motivos pelos quais você não queira participar no futuro.
+data-collection-header: Que tipos de informações este estudo coletará?
+data-collection-content: "Há {omit_video, select, true {dois} other {três}} tipos de informações coletadas neste estudo:<br><br><ol><li><strong>Informações pessoais</strong>, como seu nome, e-mail e nomes e datas de nascimento das crianças, que podem ser usadas para identificação. Isso também inclui informações da sua conta no Lookit e seu vídeo de consentimento (em que você se grava declarando que concorda em participar do estudo); isso nunca será compartilhado fora de {institution} ou do Lookit.</li><li><strong>Informações de estudo</strong>, como escolhas ou respostas que você ou sua criança dão para perguntas do estudo, descrições escritas de coisas que você faz durante o estudo, ou outras informações que você fornecer como parte da participação no estudo. Essas informações serão anonimizadas e compartilhadas com outros pesquisadores do Projeto GARDEN e, eventualmente, outros pesquisadores de desenvolvimento infantil fora do Projeto GARDEN. Você pode aprender mais sobre anonimização e compartilhamento de informações de pesquisa abaixo.</li>{omit_video, select, true {} other {<li><strong>Gravações de vídeo</strong>, de você e/ou de sua criança interagindo com qualquer parte do estudo. As gravações de vídeo são um tipo especial de informação (as pessoas podem, com certeza, ser identificadas pelo rosto!), por isso lhe daremos várias opções sobre como você gostaria que divulgássemos ou não essas informações. Consulte <strong>&ldquo;Quem poderá ver nossas gravações de vídeo&rdquo;</strong> para obter mais informações e suas escolhas.</li>}}</ol>"
+data-use-researchers-header: Para que essas informações serão utilizadas?
+data-use-researchers-content: Nunca usaremos nenhuma de suas informações para qualquer finalidade que não seja pesquisa sem fins lucrativos.<br><br>Os resultados deste estudo poderão ser apresentados em eventos científicos ou publicados em revistas científicas. Poderemos publicar respostas individuais a partir das (2) informações anonimizadas do seu estudo (consulte <strong>“Como você garante que minha privacidade está protegida?”</strong>), como por quanto tempo sua criança olhou para uma foto ou qual botão ela decidiu pressionar, mas isso só será compartilhado de forma semelhante a: “uma das muitas crianças de cinco anos que participaram escolheu esta opção durante o estudo” ou “o participante número cinco escolheu esta opção durante o estudo.” <br><br>Nós <strong>nunca compartilharemos ou publicaremos</strong> informações pessoais como seu e-mail ou datas de nascimento ou nomes de crianças.
+data-access-header: Quem tem acesso a essas informações?
+data-access-content: A realização de estudos online como o nosso exige que um pequeno número de pessoas específicas em duas universidades tenha acesso a todos os três tipos de informação. Em {institution}, o acesso é permitido a nosso grupo de pesquisa e ao Comitê de Ética de {institution}, que é um grupo que garante que seus direitos sejam protegidos quando você participa de pesquisas. No MIT, a equipe administrativa que gerencia o Lookit tem acesso. Para saber mais sobre o Lookit ou o Comitê de Ética de {institution}, consulte as perguntas específicas sobre eles abaixo.<br><br>Apenas as pessoas aprovadas pelo Comitê de Ética de {institution} para fazerem parte da equipe de investigação deste estudo ou a equipe do Lookit terão acesso às suas informações pessoais. Suas informações pessoais serão usadas apenas para garantir que você concordou com o estudo e para contatá-lo sobre este estudo ou estudos futuros do Projeto GARDEN, incluindo o envio de cartões-presente.<br><br>Suas informações de estudo serão compartilhadas com outros pesquisadores do Projeto GARDEN e, eventualmente, outros pesquisadores de desenvolvimento infantil fora do Projeto GARDEN, mas tomamos várias medidas para anonimizar você e proteger sua privacidade, removendo informações pessoais antes do compartilhamento.<br><br>Suas gravações de vídeo serão compartilhadas ou não, conforme a opção que você escolher no final do estudo.
+data-management-header: 'Como você garante que minha privacidade estará protegida com a "anonimização"?'
+data-management-content: 'Suas <u>informações de estudo</u> serão anonimizadas, fornecendo a você e a sua criança uma “ID de família” e removendo quaisquer informações pessoais que possam ser usadas para identificar vocês. Podemos dar dois exemplos de como funciona esse “processo de anonimização”:<br><br><u>Exemplo 1</u>: Em nossas planilhas de pesquisa, usaremos algo como “F32” ou “Família 32” para identificar sua família/sua criança em vez de “a família Silva” ou “Joana Silva”. Essas <u>informações de estudo</u> anonimizadas serão colocadas com outras informações de estudo anonimizadas de outras famílias&rsquo em planilhas/arquivos de dados.<br><br><u>Exemplo 2</u>: Se sua criança tiver 5 anos de idade, as informações dela serão, geralmente, descritas como uma entre muitas outras crianças de 5 anos no conjunto de dados, e relataremos descobertas dizendo algo como “as crianças de cinco anos, neste estudo, eram mais propensas a escolher a opção A com mais frequência do que outras opções” ou “200 famílias com crianças de cinco anos estavam no sudeste dos EUA”.<br><br>Se você tiver mais dúvidas sobre quem tem acesso às suas informações ou como elas serão usadas, entre em contato conosco usando as informações no final deste formulário de consentimento. Também ficaríamos felizes em compartilhar exemplos de artigos que publicamos anteriormente, para que você possa ver como usamos essas informações sem identificar as famílias participantes (exceto nos casos em que elas optaram por compartilhar suas gravações de vídeo com o público).'
+data-sharing-header: Você compartilhará minhas informações com mais alguém?
+data-sharing-content: Depois que suas <u>informações de estudo</u> forem anonimizadas (consulte <strong>“Como você garante que minha privacidade está protegida?”</strong>), elas serão compartilhadas com outros pesquisadores do Projeto GARDEN em outras universidades e serão usadas para redigir resultados de pesquisas que serão compartilhados com o público. As informações anonimizadas do estudo também serão eventualmente compartilhadas com o público para que outros pesquisadores possam verificar essas descobertas e também ver se há outras coisas importantes que podemos aprender com as informações. Isso permitirá que educadores, famílias e outros pesquisadores usem as descobertas {data_sharing_learn}.<br><br>Você terá controle total sobre quais estudos do Projeto GARDEN você deseja ou não participar. Você está concordando em participar somente de {experiment} com este formulário de consentimento.
+research-rights-irb-header: O que é o Conselho de Ética de {institution} e o que ele faz?
+research-rights-irb-content: "O Conselho de Ética é um departamento de {institution} que garante que os direitos das pessoas que participam da pesquisa sejam protegidos. {include_irb_contact_statement, select, true {Um representante do Conselho de Ética pode entrar em contato com você para coletar informações sobre sua experiência ao participar desta pesquisa. Assim como na pesquisa em si, você pode optar por responder ou não a quaisquer perguntas que um representante do Conselho de Ética possa fazer.} other {}}<br><br>Se você ou sua criança tiver dúvidas ou preocupações sobre os direitos da sua criança como sujeito de pesquisa, ou se desejar obter informações, oferecer sugestões ou relatar um problema relacionado à pesquisa, você pode entrar em contato com: {irb_contact}. {irb_extra}"
+lookit-info-header: Quem é o Lookit e o que ele faz com minhas informações?
+lookit-info-content: Lookit é um site administrado por um grupo de pesquisadores do MIT que você está usando agora para participar deste estudo. Ao se inscrever no Lookit, você fornece informações sobre você e sua família, assim o Lookit pode encontrar estudos em que você possa participar.<br><br>Como o Lookit existe apenas para ajudar nas pesquisas do site, ele não usa suas informações para nada, exceto para administrar o site; além disso, o Lookit compartilha suas informações com pesquisadores apenas se você concordar em participar de um estudo. A equipe administrativa do Lookit tem acesso a todos os três tipos de informações (gravações de vídeo, informações pessoais e informações de estudo) para verificar e garantir que o Lookit funcione bem para todas as famílias e pesquisadores, assim como para fazer melhorias no funcionamento do Lookit. As informações da sua conta são armazenadas enquanto você mantiver sua conta no Lookit, mas você tem a opção de retirar suas informações a qualquer momento.
+voluntary-participation-header: O que acontece se eu decidir não participar ou mudar de ideia sobre minha participação?
+voluntary-participation-content: "Você e sua criança podem optar por não participar deste estudo a qualquer momento. Você também pode mudar de ideia a qualquer momento. Se decidir não participar ou mudar de ideia sobre participar posteriormente, não haverá penalidades e você não perderá quaisquer benefícios desta pesquisa.<br><br>Se você decidir participar, não há problema em interromper a sessão a qualquer momento. Sinta-se à vontade para pausar, fazer um intervalo rápido ou interromper a sessão se sua criança ficar desconfortável, entediada ou decidir que não deseja mais participar!"
+video-sharing-header: Quem poderá ver minhas gravações de vídeo?
+video-sharing-consent: No início do estudo, você será solicitado a usar sua webcam para gravar seu consentimento em participar do estudo. Isso é chamado de gravação de consentimento; ela será analisada para confirmar que você concordou em participar do estudo e é elegível. Nunca iremos compartilhar sua gravação ou usá-la para qualquer outro propósito.
+video-sharing-study-all-1: 'Como parte do estudo, você será solicitado a usar sua webcam para gravar você e sua criança enquanto participa do estudo. No final do estudo, daremos algumas opções sobre se e quando poderemos compartilhar essas gravações. Estas são as opções:<br><br><ul><li><strong>Privado</strong>: "Manter meus vídeos privados": suas gravações de vídeo serão usadas apenas para este estudo e não serão compartilhadas com ninguém (nem mesmo com outros investigadores do Projeto GARDEN).</li><li><strong>Científico e educativo</strong>: "Minhas gravações de vídeo só podem ser compartilhadas para fins científicos". Suas gravações de vídeo podem ser compartilhadas para fins científicos ou educacionais, como mostrar um exemplo em uma aula universitária ou em um evento científico, ou compartilhar, ainda, com outros pesquisadores do Projeto GARDEN.</li><li><strong> Publicitário</strong>: “Minhas gravações de vídeo podem ser compartilhadas com o público”. Embora nunca mencionemos seu nome ou outras informações pessoais, suas gravações de vídeo podem ser adicionadas a bancos de dados de pesquisa públicos ou compartilhadas com o público, como, por exemplo, em notícias sobre a pesquisa ou no recrutamento de mais participantes.</li></ul >'
+video-sharing-study-all-databrary: 'Se você escolher o compartilhamento “Científico e educacional” ou “publicitário”, você também pode optar por adicionar seus vídeos à “Databrary”, que é um banco de dados de vídeos sem fins lucrativos da Universidade de Nova York que só pode ser acessado por pesquisadores autorizados, como nós, e pode ser usado apenas para fins científicos e educacionais sem fins lucrativos. Você pode ler mais sobre a Databrary em: https://databrary.org/about.html.<br><br>'
+video-sharing-study-all-2: 'Você também pode optar por remover totalmente suas gravações de vídeo do estudo no Lookit. Se você optar por isso, apenas a gravação do seu consentimento será mantida e todas as outras gravações de vídeo serão excluídas.'
+video-sharing-study-private: Os pesquisadores com acesso às suas gravações não vão compartilhá-las com mais ninguém. Ao final da sessão, você terá a opção de retirar suas gravações. Caso opte por isso, apenas a gravação do seu consentimento será mantida e todas as outras gravações serão eliminadas.
+databrary-header: Opção de Autorização para Compartilhamento da Databrary
+databrary-content: Separadamente, você pode optar por conceder acesso às suas gravações e a outros dados para usuários autorizados da biblioteca de dados segura Databrary. Isso significa que outros pesquisadores, além daqueles que conduzem este estudo, terão acesso às suas gravações e poderão utilizá-las para responder outras questões sobre o desenvolvimento infantil. O compartilhamento de dados pode levar a um progresso mais rápido na investigação sobre o desenvolvimento e o comportamento humanos. Os pesquisadores autorizados da Databrary devem concordar em manter a confidencialidade e não usar os dados para fins comerciais. Se você tiver alguma dúvida sobre esta biblioteca de compartilhamento de dados, visite <a href="https://nyu.databrary.org/" target="_blank" rel="noopener noreferrer">Databrary</a> ou envie um e-mail para ethics@databrary.org.
+contact-header: Como entrar em contato conosco
+contact-content: Este estudo é conduzido por {name} em {institution}. Se você ou sua criança tiverem alguma dúvida ou preocupação sobre este estudo, ou no caso muito improvável de uma lesão relacionada à pesquisa, entre em contato com {contact}.<br><br>Se você ou sua criança tiverem alguma dúvida ou preocupação sobre a plataforma Lookit, entre em contato com a equipe do Lookit em lookit@mit.edu.
+
 exp-lookit-exit-survey:
   Withdraw: Retirar
   acceptable-use-header: Uso de videoclipes e imagens
@@ -168,6 +248,7 @@ exp-lookit-exit-survey:
     equipe do projeto Lookit e investigadores trabalhando com {contact} no estudo
     "{name}"; o outro vídeo será excluído sem visualização.
   withdrawal-header: Remoção de dados de vídeo
+  
 exp-lookit-observation:
   Hide: Esconder
   Paused: Em pausa
@@ -191,6 +272,7 @@ exp-lookit-video-assent:
   header: A criança concorda em participar
   step-1: Saiba mais sobre o estudo
   step-2: Então decida
+  
 exp-lookit-video-consent:
   Error-starting-recorder: Erro ao iniciar gravador
   Not-recording: Não gravando
@@ -220,6 +302,7 @@ exp-lookit-video-consent:
   signed-alternative: ou em Língua Gestual Americana
   start-consent-recording: iniciar gravação de consentimento
   stop-recording: pare de gravar
+  
 exp-video-config:
   Camera: Câmera
   Microphone: Microfone
@@ -311,12 +394,9 @@ exp-video-config:
     ter certeza de que você recebeu todas as atualizações de segurança de qualquer
     maneira.)
   try-clapping: Experimente bater palmas ou dizer oi.
+  
 exp-video-config-quality:
   checkbox-warning: Por favor, marque a caixa "{completedItemText}" em cada instrução
     antes de continuar.
   recording-warning: Tente gravar e assistir a um vídeo antes de continuar.
-please wait: por favor, aguarde
-please wait, setting up: por favor espere, configurando
-return to fullscreen: voltar para tela inteira
-this-field-is-required: Este campo é obrigatório.
-uploading video: enviando vídeo
+  


### PR DESCRIPTION
Two frames were added: 
'consent-template-2'
'consent-garden'

I have added spaces (one blank line) between each frame, to add clarity when reading. 

There were a few lines after the last frame ('exp-video-config-quality') which do not belong to that frame: I have added them to the first block at the beginning, before the start of the first frame.